### PR TITLE
Fix bug where default CVSS 4 vectors default to 6.9 instead of 0

### DIFF
--- a/src/Calculators/Cvss40Calculator.php
+++ b/src/Calculators/Cvss40Calculator.php
@@ -344,7 +344,7 @@ class Cvss40Calculator implements CvssCalculator
             throw new \RuntimeException('Wrong CVSS object');
         }
 
-        if ($cvssObject->isDefaultVector()) {
+        if ($cvssObject->hasZeroImpact()) {
             return 0.0;
         }
 

--- a/src/Calculators/Cvss40Calculator.php
+++ b/src/Calculators/Cvss40Calculator.php
@@ -478,19 +478,19 @@ class Cvss40Calculator implements CvssCalculator
     {
         $availableDistance = new Cvss4Distance();
 
-        if ($lowerValues[1]) {
+        if (!is_null($lowerValues[1])) {
             $availableDistance->eqOne = $initalValue - $lowerValues[1];
         }
-        if ($lowerValues[2]) {
+        if (!is_null($lowerValues[2])) {
             $availableDistance->eqTwo = $initalValue - $lowerValues[2];
         }
-        if ($lowerValues[3]) {
+        if (!is_null($lowerValues[3])) {
             $availableDistance->eqThree = $initalValue - $lowerValues[3];
         }
-        if ($lowerValues[4]) {
+        if (!is_null($lowerValues[4])) {
             $availableDistance->eqFour = $initalValue - $lowerValues[4];
         }
-        if ($lowerValues[5]) {
+        if (!is_null($lowerValues[5])) {
             $availableDistance->eqFive = $initalValue - $lowerValues[5];
         }
 

--- a/src/Calculators/Cvss40Calculator.php
+++ b/src/Calculators/Cvss40Calculator.php
@@ -344,6 +344,10 @@ class Cvss40Calculator implements CvssCalculator
             throw new \RuntimeException('Wrong CVSS object');
         }
 
+        if ($cvssObject->isDefaultVector()) {
+            return 0.0;
+        }
+
         $initialValue = $this->lookupMicroVector($cvssObject->getMicroVector());
 
         if (!is_float($initialValue)) {

--- a/src/Parsers/Cvss31Parser.php
+++ b/src/Parsers/Cvss31Parser.php
@@ -97,7 +97,7 @@ class Cvss31Parser
     {
         $modifiedScopeValue = self::findOptionalValueInVector($vector, self::ENVIRONMENTAL_MODIFIED_SCOPE);
 
-        if ($modifiedScopeValue && $modifiedScopeValue !== self::NOT_DEFINED) {
+        if (!is_null($modifiedScopeValue) && $modifiedScopeValue !== self::NOT_DEFINED) {
             $cvssObject->modifiedScope = $modifiedScopeValue;
         }
 
@@ -113,31 +113,31 @@ class Cvss31Parser
         $modifiedIntegrityValue = self::findOptionalValueInVector($vector, self::ENVIRONMENTAL_MODIFIED_INTEGRITY);
         $modifiedAvailabilityValue = self::findOptionalValueInVector($vector, self::ENVIRONMENTAL_MODIFIED_AVAILABILITY);
 
-        if ($modifiedAttackVectorValue && $modifiedAttackVectorValue !== self::NOT_DEFINED) {
+        if (!is_null($modifiedAttackVectorValue) && $modifiedAttackVectorValue !== self::NOT_DEFINED) {
             $cvssObject->modifiedAttackVector = self::parseAttackVector($modifiedAttackVectorValue);
         }
 
-        if ($modifiedAttackComplexityValue && $modifiedAttackComplexityValue !== self::NOT_DEFINED) {
+        if (!is_null($modifiedAttackComplexityValue) && $modifiedAttackComplexityValue !== self::NOT_DEFINED) {
             $cvssObject->modifiedAttackComplexity = self::parseAttackComplexity($modifiedAttackComplexityValue);
         }
 
-        if ($modifiedPrivilegesRequiredValue && $modifiedPrivilegesRequiredValue !== self::NOT_DEFINED) {
+        if (!is_null($modifiedPrivilegesRequiredValue) && $modifiedPrivilegesRequiredValue !== self::NOT_DEFINED) {
             $cvssObject->modifiedPrivilegesRequired = self::parsePrivilegesRequired($modifiedPrivilegesRequiredValue, $cvssObject->modifiedScope);
         }
 
-        if ($modifiedUserInteractionValue && $modifiedUserInteractionValue !== self::NOT_DEFINED) {
+        if (!is_null($modifiedUserInteractionValue) && $modifiedUserInteractionValue !== self::NOT_DEFINED) {
             $cvssObject->modifiedUserInteraction = self::parseUserInteraction($modifiedUserInteractionValue);
         }
 
-        if ($modifiedConfidentialityValue && $modifiedConfidentialityValue !== self::NOT_DEFINED) {
+        if (!is_null($modifiedConfidentialityValue) && $modifiedConfidentialityValue !== self::NOT_DEFINED) {
             $cvssObject->modifiedConfidentiality = self::parseConfidentialityIntegrityOrAvailability($modifiedConfidentialityValue);
         }
 
-        if ($modifiedIntegrityValue && $modifiedIntegrityValue !== self::NOT_DEFINED) {
+        if (!is_null($modifiedIntegrityValue) && $modifiedIntegrityValue !== self::NOT_DEFINED) {
             $cvssObject->modifiedIntegrity = self::parseConfidentialityIntegrityOrAvailability($modifiedIntegrityValue);
         }
 
-        if ($modifiedAvailabilityValue && $modifiedAvailabilityValue !== self::NOT_DEFINED) {
+        if (!is_null($modifiedAvailabilityValue) && $modifiedAvailabilityValue !== self::NOT_DEFINED) {
             $cvssObject->modifiedAvailability = self::parseConfidentialityIntegrityOrAvailability($modifiedAvailabilityValue);
         }
 

--- a/src/Parsers/Cvss40Parser.php
+++ b/src/Parsers/Cvss40Parser.php
@@ -317,7 +317,7 @@ class Cvss40Parser
     {
         $result = $this->findOptionalValueInVector($vector, $section);
 
-        if (!$result) {
+        if (is_null($result)) {
             throw CvssException::missingValue();
         }
 

--- a/src/ValueObjects/Cvss4Object.php
+++ b/src/ValueObjects/Cvss4Object.php
@@ -34,6 +34,11 @@ class Cvss4Object extends CvssObject
         return $this->eq1 . $this->eq2 . $this->eq3 . $this->eq4 . $this->eq5 . $this->eq6;
     }
 
+    public function isDefaultVector(): bool
+    {
+        return $this->vc === 0.2 && $this->vi === 0.2 && $this->va === 0.2 && $this->sc === 0.3 && $this->si === 0.3 && $this->sa === 0.3;
+    }
+
     public function getLowerVectors(): array
     {
         $vectors = [

--- a/src/ValueObjects/Cvss4Object.php
+++ b/src/ValueObjects/Cvss4Object.php
@@ -34,7 +34,7 @@ class Cvss4Object extends CvssObject
         return $this->eq1 . $this->eq2 . $this->eq3 . $this->eq4 . $this->eq5 . $this->eq6;
     }
 
-    public function isDefaultVector(): bool
+    public function hasZeroImpact(): bool
     {
         return $this->vc === 0.2 && $this->vi === 0.2 && $this->va === 0.2 && $this->sc === 0.3 && $this->si === 0.3 && $this->sa === 0.3;
     }

--- a/tests/CvssTest.php
+++ b/tests/CvssTest.php
@@ -46,6 +46,7 @@ class CvssTest extends TestCase
             ['CVSS:4.0/AV:A/AC:H/AT:P/PR:L/UI:P/VC:L/VI:H/VA:L/SC:L/SI:H/SA:L/E:P/CR:M/IR:L/AR:M/MAV:N/MAC:H/MAT:P/MPR:L/MUI:P/MVC:L/MVI:H/MVA:L/MSC:H/MSI:L/MSA:L/S:N/AU:N/R:U/V:D/RE:L/U:Green', 4.9, 4.9, 4.9],
             ['CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/MAV:N/MAC:L/MAT:N/MPR:N/MUI:N/S:N/AU:N/R:A/V:D/RE:L/U:Clear', 6.9, 6.9, 6.9],
             ['CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/S:N/AU:N/R:A/V:D/RE:L/U:Clear', 6.9, 6.9, 6.9],
+            ['CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N', 0, 0, 0],
 
             ['CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H', 8.0, 8.0, 8.0],
             ['CVSS:3.1/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:N/RL:U', 0.0, 0.0, 0.0],


### PR DESCRIPTION
Missing behavior in CVSS 4.0 Calculator where if no Vulnerable System Impact Metrics or Subsequent System Impact Metrics were set, the calculator should fall back to zero. The previous behavior was just running correctly based on the exploitablity metrics.