### PR TITLE
Fix CVSS 4.0 score when a lower macrovector ties the current score

### DIFF
--- a/src/Calculators/Cvss40Calculator.php
+++ b/src/Calculators/Cvss40Calculator.php
@@ -383,7 +383,7 @@ final class Cvss40Calculator implements CvssCalculator
         $severityDistance = $this->calculateSeverityDistance($cvssObject, $maxVector);
 
         $availableDistance = $this->calculateAvailableDistance($initialValue, $lowerVectorValues);
-        $finalValue = $initialValue - $this->calculateMeanDistance($cvssObject, $severityDistance, $availableDistance);
+        $finalValue = $initialValue - $this->calculateMeanDistance($cvssObject, $severityDistance, $availableDistance, $lowerVectorValues);
 
         if ($finalValue < 0.0) {
             return 0.0;
@@ -519,12 +519,15 @@ final class Cvss40Calculator implements CvssCalculator
         );
     }
 
-    private function calculateMeanDistance(Cvss4Object $cvssObject, Cvss4Distance $severityDistance, Cvss4Distance $availableDistance): float
+    /**
+     * @param float[]|null[] $lowerValues
+     */
+    private function calculateMeanDistance(Cvss4Object $cvssObject, Cvss4Distance $severityDistance, Cvss4Distance $availableDistance, array $lowerValues): float
     {
         $normalisedSeverity = new Cvss4Distance();
         $existingLower = 0;
 
-        if ($availableDistance->eqOne) {
+        if (!is_null($lowerValues[1])) {
             $existingLower++;
 
             if (!isset($this->maxSeverity[1][$cvssObject->eq1]) || !is_int($this->maxSeverity[1][$cvssObject->eq1])) {
@@ -535,7 +538,7 @@ final class Cvss40Calculator implements CvssCalculator
             $normalisedSeverity->eqOne = $availableDistance->eqOne * ($severityDistance->eqOne / $maxSeverityOne);
         }
 
-        if ($availableDistance->eqTwo) {
+        if (!is_null($lowerValues[2])) {
             $existingLower++;
 
             if (!isset($this->maxSeverity[2][$cvssObject->eq2]) || !is_int($this->maxSeverity[2][$cvssObject->eq2])) {
@@ -546,7 +549,7 @@ final class Cvss40Calculator implements CvssCalculator
             $normalisedSeverity->eqTwo = $availableDistance->eqTwo * ($severityDistance->eqTwo / $maxSeverityTwo);
         }
 
-        if ($availableDistance->eqThree) {
+        if (!is_null($lowerValues[3])) {
             $existingLower++;
 
             if (!isset($this->maxSeverity[3][$cvssObject->eq3][$cvssObject->eq6]) || !is_int($this->maxSeverity[3][$cvssObject->eq3][$cvssObject->eq6])) {
@@ -557,7 +560,7 @@ final class Cvss40Calculator implements CvssCalculator
             $normalisedSeverity->eqThree = $availableDistance->eqThree * ($severityDistance->eqThree / $maxSeverityThree);
         }
 
-        if ($availableDistance->eqFour) {
+        if (!is_null($lowerValues[4])) {
             $existingLower++;
 
             if (!isset($this->maxSeverity[4][$cvssObject->eq4]) || !is_int($this->maxSeverity[4][$cvssObject->eq4])) {
@@ -568,7 +571,7 @@ final class Cvss40Calculator implements CvssCalculator
             $normalisedSeverity->eqFour = $availableDistance->eqFour * ($severityDistance->eqFour / $maxSeverityFour);
         }
 
-        if ($availableDistance->eqFive) {
+        if (!is_null($lowerValues[5])) {
             $existingLower++;
             $normalisedSeverity->eqFive = 0;
         }

--- a/tests/CvssTest.php
+++ b/tests/CvssTest.php
@@ -48,6 +48,8 @@ class CvssTest extends TestCase
             ['CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N/S:N/AU:N/R:A/V:D/RE:L/U:Clear', 6.9, 6.9, 6.9],
             ['CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:A/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N/E:X/CR:X/IR:X/AR:X/MAV:X/MAC:X/MAT:X/MPR:X/MUI:X/MVC:X/MVI:X/MVA:X/MSC:X/MSI:X/MSA:X/S:X/AU:X/R:X/V:X/RE:X/U:X', 7.5, 7.5, 7.5],
             ['CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N', 0, 0, 0],
+            // Regression test for #20
+            ['CVSS:4.0/AV:N/AC:L/AT:P/PR:H/UI:P/VC:L/VI:H/VA:L/SC:H/SI:H/SA:H/E:P/MAV:L/MAC:H/MAT:P/MPR:N/MUI:P', 5.6, 5.6, 5.6],
 
 
             ['CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H', 8.0, 8.0, 8.0],


### PR DESCRIPTION
# Fix CVSS 4.0 score bias when a lower macrovector ties the current score

Closes #20 

## Summary

CVSS 4.0 vectors can be scored ~0.1 too low whenever an equivalence class (EQ) has a *defined* lower macrovector that happens to score the same as the current macrovector. The bug is in `Cvss40Calculator::calculateMeanDistance()`.

## Reproduction

```
CVSS:4.0/AV:N/AC:L/AT:P/PR:H/UI:P/VC:L/VI:H/VA:L/SC:H/SI:H/SA:H/E:P/MAV:L/MAC:H/MAT:P/MPR:N/MUI:P
```

- This library returns **5.5**
- The FIRST.org reference calculator returns **5.6**
  (https://www.first.org/cvss/calculator/4.0#CVSS:4.0/AV:N/AC:L/AT:P/PR:H/UI:P/VC:L/VI:H/VA:L/SC:H/SI:H/SA:H/E:P/MAV:L/MAC:H/MAT:P/MPR:N/MUI:P)

## Root cause

The final score is `initialValue − meanDistance`, where the mean distance sums per-EQ contributions and divides by the number of EQs that have a defined lower macrovector.

`calculateMeanDistance()` selected which EQs count with a truthy check on the float available distance:

```php
if ($availableDistance->eqThree) { $existingLower++; ... }
```

`Cvss4Distance` types every field as a plain, non-nullable `float` defaulting to `0.0`, and `calculateAvailableDistance()` only overwrites a field when the lower macrovector exists. So two different states collapse to the same falsy `0.0`:

- **no lower macrovector** (should be excluded), and
- **lower macrovector exists but scores the same as the current one**, giving an available distance of exactly `0.0` (should be **included**).

Excluding the second case shrinks the divisor, inflates the mean distance, and biases the score downward.

For the vector above (macrovector `111110`, initial `5.7`):

| EQ | lower vector | defined? | avail. dist | contribution |
|----|--------------|----------|-------------|--------------|
| 1  | `211110`     | yes (4.8)| 0.9         | 0.45 |
| 2  | `121110`     | no       | —           | skipped |
| 3  | `111111`     | yes (5.7)| **0.0**     | 0.0 |
| 4  | `111210`     | yes (5.7)| **0.0**     | 0.0 |
| 5  | `111120`     | yes (4.7)| 1.0         | 0.0 |

- Reference: divisor 4 → mean 0.1125 → 5.7 − 0.1125 = 5.5875 → **5.6**
- Before fix: EQ3/EQ4 dropped → divisor 2 → mean 0.225 → 5.475 → **5.5**

## Fix

Gate each EQ on whether its lower macrovector is *defined* (`!is_null($lowerValues[n])`) instead of the truthiness of the distance, matching the FIRST reference. The `$lowerVectorValues` array — whose elements are `?float` (`lookupMicroVector()` returns `null` for an undefined macrovector) — is passed into `calculateMeanDistance()`. Normalized-severity contributions still use `$availableDistance` and correctly remain `0.0` in the tie case, so only the divisor changes.

Added a regression test for the affected string.
